### PR TITLE
Correct link to .dmg

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,4 @@
 
-
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
   "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 
@@ -59,7 +58,7 @@ img { border: 0; }
 <h3>Download</h3>
 
 <a href="http://github.com/downloads/wummel/linkchecker/LinkChecker-8.4.exe">LinkChecker&nbsp;8.4&nbsp;for&nbsp;Windows</a><br/>
-<a href="http://sourceforge.net/projects/linkchecker/files/7.0/LinkChecker-7.0.dmg">LinkChecker&nbsp;7.0&nbsp;for&nbsp;Mac&nbsp;OS&nbsp;X</a><br/>
+<a href="http://sourceforge.net/projects/linkchecker/files/old-releases/7.0/LinkChecker-7.0.dmg">LinkChecker&nbsp;7.0&nbsp;for&nbsp;Mac&nbsp;OS&nbsp;X</a><br/>
 <a href="http://ftp.debian.org/debian/pool/main/l/linkchecker/">LinkChecker&nbsp;8.4&nbsp;for&nbsp;Debian</a><br/>
 <a href="http://github.com/downloads/wummel/linkchecker/LinkChecker-8.4.tar.xz">LinkChecker&nbsp;8.4&nbsp;source</a><br/>
 <a href="https://github.com/wummel/linkchecker/blob/master/doc/changelog.txt">Changelog</a><br/>


### PR DESCRIPTION
The dmg on sourceforge has been moved into a /old-releases/ directory.
