### PR TITLE
Allow quotes in cookie values, and don't quote cookie values when sending to the server

### DIFF
--- a/linkcheck/cookies.py
+++ b/linkcheck/cookies.py
@@ -48,7 +48,7 @@ has_embedded_dot = re.compile(r"[a-zA-Z0-9]\.[a-zA-Z]").search
 
 # Pattern for finding cookie snatched from Pythons Cookie.py
 # Modification: allow whitespace in values.
-LegalChars = r"\w\d!#%&'~_`><@,:/\$\*\+\-\.\^\|\)\(\?\}\{\="
+LegalChars = r"\w\d!#%&'~_`><@,:/\"\$\*\+\-\.\^\|\)\(\?\}\{\="
 CookiePattern = re.compile(r"""
     (?P<key>                   # Start of group 'key'
     [%(legalchars)s]+?         # Any word of at least one letter, nongreedy
@@ -303,7 +303,7 @@ class HttpCookie (object):
         parts = []
         if "version" in self.attributes:
             parts.append("$Version=%s" % quote(self.attributes["version"]))
-        parts.append("%s=%s" % (self.name, quote(self.value)))
+        parts.append("%s=%s" % (self.name, self.value))
         parts.extend(["$%s=%s"% (self.attribute_names[k], self.quote(k, v)) \
                   for k, v in self.attributes.items() if k != "version"])
         return "; ".join(parts)


### PR DESCRIPTION
I've had this logiic running in my fork for over a year now with no apparent issues. This is the original email I sent to the mailing list about it:

> I've got a site sending a cookie whose value looks like a JSON object, e.g., {"name1":"val 1","name2":"val 2"};
> This violates the cookie specs in many ways, but browsers don't seem to have any problem with it. It looks like > linkchecker is already allowing commas and whitespace in cookie values, so only double-quotes are causing > > parsing issues in this example. 
> 
> If we allow quotes, however, linkchecker escapes them while wrapping the entire value in a pair of double  quotes. I was not able to make the site in question happy until I removed the quoting/escaping logic while sending > cookies. 
> 
> It appears that Firefox does not quote cookie values either. I did not check any other browsers. 
