### PR TITLE
Reset to original url when falling back to GET

### DIFF
--- a/linkcheck/checker/httpurl.py
+++ b/linkcheck/checker/httpurl.py
@@ -283,6 +283,8 @@ class HttpUrl (internpaturl.InternPatternUrl, proxysupport.ProxySupport, pooledc
 
     def fallback_to_get(self):
         """Set method to GET and clear aliases."""
+        self.close_response()
+        self.close_connection()
         self.method = "GET"
         self.aliases = []
         self.urlparts = strformat.url_unicode_split(self.url)


### PR DESCRIPTION
Among the many idiosyncrasies with IIS/ASP.net and HEAD requests are that it sometimes returns a 302 redirect to a nonexistent error page, whereas a GET request to the original url returns a 200 response. If we revert back to the original url when falling back to GET from a failed HEAD request, it prevents bogus 404s from the non-existent redirect url.
