### PR TITLE
Add maxfilesize config option

### DIFF
--- a/config/linkcheckerrc
+++ b/config/linkcheckerrc
@@ -188,6 +188,9 @@
 #maxconnectionshttp=10
 #maxconnectionshttps=10
 #maxconnectionsftp=2
+# Maximum size in bytes for downloaded files. Any URL with a larger file size
+# will be skipped. 
+#maxfilesize=1500000
 
 ##################### filtering options ##########################
 [filtering]

--- a/doc/en/linkcheckerrc.5
+++ b/doc/en/linkcheckerrc.5
@@ -170,6 +170,13 @@ Maximum number of connections to FTP servers.
 .br
 The default is 2.
 .br
+.TP
+\fBmaxfilesize=\fP\fINUMBER\fP
+Maximum size in bytes for downloaded files. Any URL with a larger file size
+will be skipped.
+.br
+The default is 5MB.
+.br
 Command line option: none
 .SS \fB[filtering]\fP
 .TP

--- a/linkcheck/checker/fileurl.py
+++ b/linkcheck/checker/fileurl.py
@@ -203,7 +203,7 @@ class FileUrl (urlbase.UrlBase):
     def read_content (self):
         """Return file content, or in case of directories a dummy HTML file
         with links to the files."""
-        if self.size > self.MaxFilesizeBytes:
+        if self.size > self.aggregate.config["maxfilesize"]:
             raise LinkCheckerError(_("File size too large"))
         if self.is_directory():
             data = get_index_html(get_files(self.get_os_filename()))

--- a/linkcheck/checker/ftpurl.py
+++ b/linkcheck/checker/ftpurl.py
@@ -220,7 +220,7 @@ class FtpUrl (internpaturl.InternPatternUrl, proxysupport.ProxySupport, pooledco
                 urls = self.aggregate.add_download_data(self.cache_content_key, s)
                 self.warn_duplicate_content(urls)
                 # limit the download size
-                if (buf.tell() + len(s)) > self.MaxFilesizeBytes:
+                if (buf.tell() + len(s)) > self.aggregate.config["maxfilesize"]:
                     raise LinkCheckerError(_("FTP file size too large"))
                 buf.write(s)
             self.url_connection.retrbinary(ftpcmd, stor_data)

--- a/linkcheck/checker/httpurl.py
+++ b/linkcheck/checker/httpurl.py
@@ -666,15 +666,15 @@ class HttpUrl (internpaturl.InternPatternUrl, proxysupport.ProxySupport, pooledc
             # Re-read size info, since the GET request result could be different
             # than a former HEAD request.
             self.add_size_info()
-        if self.size > self.MaxFilesizeBytes:
+        if self.size > self.aggregate.config["maxfilesize"]:
             raise LinkCheckerError(_("File size too large"))
         self.charset = headers.get_charset(self.headers)
         return self._read_content()
 
     def _read_content (self):
         """Read URL contents."""
-        data = self.response.read(self.MaxFilesizeBytes+1)
-        if len(data) > self.MaxFilesizeBytes:
+        data = self.response.read(self.aggregate.config["maxfilesize"]+1)
+        if len(data) > self.aggregate.config["maxfilesize"]:
             raise LinkCheckerError(_("File size too large"))
         dlsize = len(data)
         urls = self.aggregate.add_download_data(self.cache_content_key, data)

--- a/linkcheck/checker/urlbase.py
+++ b/linkcheck/checker/urlbase.py
@@ -104,9 +104,6 @@ class UrlBase (object):
         "text/vnd.wap.wml": "wml",
     }
 
-    # Set maximum file size for downloaded files in bytes.
-    MaxFilesizeBytes = 1024*1024*5
-
     def __init__ (self, base_url, recursion_level, aggregate,
                   parent_url=None, base_ref=None, line=-1, column=-1,
                   name=u"", url_encoding=None, extern=None):
@@ -756,10 +753,10 @@ class UrlBase (object):
     def read_content (self):
         """Return data and data size for this URL.
         Can be overridden in subclasses."""
-        if self.size > self.MaxFilesizeBytes:
+        if self.size > self.aggregate.config["maxfilesize"]:
             raise LinkCheckerError(_("File size too large"))
-        data = self.url_connection.read(self.MaxFilesizeBytes+1)
-        if len(data) > self.MaxFilesizeBytes:
+        data = self.url_connection.read(self.aggregate.config["maxfilesize"]+1)
+        if len(data) > self.aggregate.config["maxfilesize"]:
             raise LinkCheckerError(_("File size too large"))
         if not self.is_local():
             urls = self.aggregate.add_download_data(self.cache_content_key, data)

--- a/linkcheck/configuration/__init__.py
+++ b/linkcheck/configuration/__init__.py
@@ -230,6 +230,7 @@ class Configuration (dict):
         self["maxconnectionshttp"] = 10
         self["maxconnectionshttps"] = 10
         self["maxconnectionsftp"] = 2
+        self["maxfilesize"] = 1024*1024*5
         from ..logger import Loggers
         self.loggers = dict(**Loggers)
 

--- a/linkcheck/configuration/confparse.py
+++ b/linkcheck/configuration/confparse.py
@@ -167,6 +167,7 @@ class LCConfigParser (ConfigParser.RawConfigParser, object):
         self.read_string_option(section, "localwebroot")
         self.read_int_option(section, "warnsslcertdaysvalid", min=1)
         self.read_int_option(section, "maxrunseconds", min=0)
+        self.read_int_option(section, "maxfilesize", min=1)
 
     def read_authentication_config (self):
         """Read configuration options in section "authentication"."""


### PR DESCRIPTION
Replaces the MaxFilesizeBytes constant with a configurable setting, defaulting to the old value of 5MB. 

I've had a site serving up a 4MB pdf file as text/html, causing linkchecker to spin for hours trying to parse it. I wish I knew how to detect that specific issue, but at least ignoring very large files allows linkchecker to complete in a reasonable amount of time.
