### PR TITLE
Fix ISO formatting for modified datetime.

### DIFF
--- a/linkcheck/logger/__init__.py
+++ b/linkcheck/logger/__init__.py
@@ -436,14 +436,14 @@ class Logger (object):
         self.stats.downloaded_bytes = download_stats
 
     def format_modified(self, modified, sep=" "):
-        """Format modification date if it's not None.
-        @param modified: modification date
+        """Format modification date in UTC if it's not None.
+        @param modified: modification date in UTC
         @ptype modified: datetime or None
         @return: formatted date or empty string
         @rtype: unicode
         """
         if modified is not None:
-            return modified.isoformat(sep)
+            return modified.strftime("%Y-%m-%d{0}%H:%M:%S.%fZ".format(sep))
         return u""
 
 


### PR DESCRIPTION
This change will make sure that format_modified returns datetime value
in ISO 8601 format. See W3C documentation at
http://www.w3.org/TR/NOTE-datetime.

Since `modified` is parsed and then converted to UTC after it's
extracted from HTTP response, it's safe to assume that format_modified
will always format UTC datetime values.

Instead of `isoformat` method which omits timezone information for
UTC values, `strftime` with a specific format (that ends with Z)
will be used.
