### PR TITLE
Fix non-standard deskop file

### DIFF
--- a/doc/linkchecker-gui.desktop
+++ b/doc/linkchecker-gui.desktop
@@ -1,10 +1,10 @@
 [Desktop Entry]
-Name=LinkChecker Gui
+Name=LinkChecker GUI
 GenericName=URL validator
 GenericName[de]=URL Validator
 Version=1.0
 Type=Application
 Exec=linkchecker-gui
 Terminal=false
-Categories=Network;WebDevelopment
+Categories=Network;WebDevelopment;
 Icon=logo48x48


### PR DESCRIPTION
desktop-file-validate /home/rpmaker/rpmbuild/BUILDROOT/linkchecker-8.6-1.fc21.i386/usr/share/applications/linkchecker-gui.desktop:

/home/rpmaker/rpmbuild/BUILDROOT/linkchecker-8.6-1.fc21.i386/usr/share/applications/linkchecker-gui.desktop: error: value "Network;WebDevelopment" for string list key "Categories" in group "Desktop Entry" does not have a semicolon (';') as trailing character

/home/rpmaker/rpmbuild/BUILDROOT/linkchecker-8.6-1.fc21.i386/usr/share/applications/linkchecker.desktop: error: value "True" for boolean key "Terminal" in group "Desktop Entry" contains invalid characters, boolean values must be "false" or "true"
/home/rpmaker/rpmbuild/BUILDROOT/linkchecker-8.6-1.fc21.i386/usr/share/applications/linkchecker.desktop: error: value "Network;WebDevelopment" for string list key "Categories" in group "Desktop Entry" does not have a semicolon (';') as trailing character
