### PR TITLE
Disable warnings if --no-warnings is passed or they are disabled in config file

### DIFF
--- a/linkchecker
+++ b/linkchecker
@@ -461,7 +461,7 @@ if options.debug and not __debug__:
 # apply commandline options and arguments to configuration
 constructauth = False
 do_profile = False
-if options.warnings:
+if not options.warnings:
     config["warnings"] = options.warnings
 if options.anchors:
     config["anchors"] = options.anchors


### PR DESCRIPTION
A colleague and me noticed that passing `--no-warnings` to linkchecker did not actually disable the warnings. I later also noticed that disabling them in the configuration file did not help either, the only way (apart from patching the code ;)) was to disable them in the configuration file _and_ passing `--no-warnings`. It seems like this was broken since b38317d5 where optparse was replaced with argparse, and the change in this pull request seems to fix it.
