### PR TITLE
Ignore urls after non-whitespace for intern match

### DIFF
--- a/linkcheck/checker/internpaturl.py
+++ b/linkcheck/checker/internpaturl.py
@@ -43,7 +43,7 @@ def get_intern_pattern (url):
     if args[0] in ('http', 'https'):
         args[0] = 'https?'
     args[1] = r"(www\.|)%s" % args[1]
-    return "%s://%s%s" % tuple(args)
+    return "^\s*%s://%s%s" % tuple(args)
 
 
 class InternPatternUrl (urlbase.UrlBase):


### PR DESCRIPTION
This prevents matching a URL on an external site with the URL of the origin server passed in the querystring. This is common in the case of generating a share URL on social media that points back to the original page. Resolves #509.
