### PR TITLE
Handle sitemap XML parse error as warning

### DIFF
--- a/linkcheck/checker/const.py
+++ b/linkcheck/checker/const.py
@@ -100,6 +100,7 @@ WARN_IGNORE_URL = "ignore-url"
 WARN_MAIL_NO_MX_HOST = "mail-no-mx-host"
 WARN_NNTP_NO_SERVER = "nntp-no-server"
 WARN_NNTP_NO_NEWSGROUP = "nntp-no-newsgroup"
+WARN_XML_PARSE_ERROR = "xml-parse-error"
 
 # registered warnings
 Warnings = {
@@ -123,4 +124,5 @@ Warnings = {
     WARN_NNTP_NO_SERVER: _("No NNTP server was found."),
     WARN_NNTP_NO_NEWSGROUP: _("The NNTP newsgroup could not be found."),
     WARN_URL_OBFUSCATED_IP: _("The IP is obfuscated."),
+    WARN_XML_PARSE_ERROR: _("XML could not be parsed."),
 }

--- a/linkcheck/director/checker.py
+++ b/linkcheck/director/checker.py
@@ -52,15 +52,15 @@ def check_url(url_data, logger):
                 url_data.check()
                 do_parse = url_data.check_content()
                 url_data.checktime = time.time() - check_start
+                # parse content recursively
+                if do_parse:
+                    parser.parse_url(url_data)
                 # Add result to cache
                 result = url_data.to_wire()
                 cache.add_result(key, result)
                 for alias in url_data.aliases:
                     # redirect aliases
                     cache.add_result(alias, result)
-                # parse content recursively
-                if do_parse:
-                    parser.parse_url(url_data)
             finally:
                 # close/release possible open connection
                 url_data.close_connection()

--- a/linkcheck/parser/sitemap.py
+++ b/linkcheck/parser/sitemap.py
@@ -18,7 +18,8 @@
 Main functions for link parsing
 """
 from xml.parsers.expat import ParserCreate
-
+from xml.parsers.expat import ExpatError
+from ..checker.const import (WARN_XML_PARSE_ERROR)
 
 class XmlTagUrlParser(object):
     """Parse XML files and find URLs in text content of a tag name."""
@@ -40,8 +41,10 @@ class XmlTagUrlParser(object):
         self.url = u""
         data = url_data.get_content()
         isfinal = True
-        self.parser.Parse(data, isfinal)
-
+        try:
+            self.parser.Parse(data, isfinal)
+        except ExpatError as expaterr:
+            self.url_data.add_warning(expaterr.message,tag=WARN_XML_PARSE_ERROR)
     def start_element(self, name, attrs):
         """Set tag status for start element."""
         self.in_tag = (name == self.tag)


### PR DESCRIPTION
I've added a warning type, and we are catching a expat parser error and relaying it as a warning, rather than resulting in an internal error. resolve #506.

I've reopened this as a pull request since I had to branch it to do other work... Sorry for my github noobness.
