### PR TITLE
Fix requests requirement error message

### DIFF
--- a/linkcheck/__init__.py
+++ b/linkcheck/__init__.py
@@ -27,7 +27,7 @@ if not (hasattr(sys, 'version_info') or
     raise SystemExit("This program requires Python 2.7.2 or later.")
 import requests
 if requests.__version__ <= '2.2.0':
-    raise SystemExit("This program requires Python requests 2.2.0 or later.")
+    raise SystemExit("This program requires Python requests above version 2.2.0.")
 
 import os
 # add the custom linkcheck_dns directory to sys.path


### PR DESCRIPTION
Error message stated that we need requests v. 2.2.0 or later, but the `if` statement is `<= '2.2.0'`.