### PR TITLE
Make documentation reflect 39df181

### DIFF
--- a/config/linkcheckerrc
+++ b/config/linkcheckerrc
@@ -128,7 +128,7 @@
 ##################### checking options ##########################
 [checking]
 # number of threads
-#threads=100
+#threads=10
 # connection timeout in seconds
 #timeout=60
 # Time to wait for checks to finish after the user aborts the first time

--- a/doc/de.po
+++ b/doc/de.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: linkchecker 3.4\n"
-"POT-Creation-Date: 2014-04-28 17:04+0300\n"
+"POT-Creation-Date: 2015-09-15 10:52+0200\n"
 "PO-Revision-Date: 2013-12-12 21:51+0100\n"
 "Last-Translator: Bastian Kleineidam <calvin@users.sourceforge.net>\n"
 "Language-Team: de <de@li.org>\n"
@@ -338,12 +338,16 @@ msgstr "B<-t>I<NUMMER>, B<--threads=>I<NUMMER>"
 # type: Plain text
 #. type: Plain text
 #: en/linkchecker.1:76 en/linkcheckerrc.5:47
+#, fuzzy
+#| msgid ""
+#| "Generate no more than the given number of threads. Default number of "
+#| "threads is 10. To disable threading specify a non-positive number."
 msgid ""
 "Generate no more than the given number of threads. Default number of threads "
-"is 100. To disable threading specify a non-positive number."
+"is 10. To disable threading specify a non-positive number."
 msgstr ""
-"Generiere nicht mehr als die angegebene Anzahl von Threads. Standard Anzahl "
-"von Threads ist 100. Um Threads zu deaktivieren, geben Sie eine nicht "
+"Generiere nicht mehr als die angegebene Anzahl von Threads. Die Standardanzahl "
+"von Threads ist 10. Um Threads zu deaktivieren, geben Sie eine nicht "
 "positive Nummer an."
 
 # type: TP
@@ -779,8 +783,8 @@ msgstr "KONFIGURATIONSDATEIEN"
 #: en/linkchecker.1:207
 msgid ""
 "Configuration files can specify all options above. They can also specify "
-"some options that cannot be set on the command line.  See B<linkcheckerrc>"
-"(5) for more info."
+"some options that cannot be set on the command line.  See "
+"B<linkcheckerrc>(5) for more info."
 msgstr ""
 "Konfigurationsdateien können alle obigen Optionen enthalten. Sie können "
 "zudem Optionen enthalten, welche nicht auf der Kommandozeile gesetzt werden "
@@ -1803,8 +1807,8 @@ msgid ""
 "Read a file with initial cookie data. The cookie data format is explained in "
 "linkchecker(1)."
 msgstr ""
-"Lese eine Datei mit Cookie-Daten. Das Cookie Datenformat wird in linkchecker"
-"(1) erklärt."
+"Lese eine Datei mit Cookie-Daten. Das Cookie Datenformat wird in "
+"linkchecker(1) erklärt."
 
 # type: Plain text
 #. type: Plain text

--- a/doc/de/linkchecker.1
+++ b/doc/de/linkchecker.1
@@ -81,9 +81,8 @@ Lese Liste von URLs zum Prüfen von der Standardeingabe, getrennt durch
 Leerzeichen.
 .TP 
 \fB\-t\fP\fINUMMER\fP, \fB\-\-threads=\fP\fINUMMER\fP
-Generiere nicht mehr als die angegebene Anzahl von Threads. Standard Anzahl
-von Threads ist 100. Um Threads zu deaktivieren, geben Sie eine nicht
-positive Nummer an.
+Generiere nicht mehr als die angegebene Anzahl von Threads. Die Standardanzahl von Threads ist 10.
+Um Threads zu deaktivieren, geben Sie eine nicht positive Nummer an.
 .TP 
 \fB\-V\fP, \fB\-\-version\fP
 Gebe die Version aus und beende das Programm.

--- a/doc/de/linkcheckerrc.5
+++ b/doc/de/linkcheckerrc.5
@@ -47,9 +47,8 @@ bewirkt unendliche Rekursion. Standard Tiefe ist unendlich.
 Kommandozeilenoption: \fB\-\-recursion\-level\fP
 .TP 
 \fBthreads=\fP\fINUMBER\fP
-Generiere nicht mehr als die angegebene Anzahl von Threads. Standard Anzahl
-von Threads ist 100. Um Threads zu deaktivieren, geben Sie eine nicht
-positive Nummer an.
+Generiere nicht mehr als die angegebene Anzahl von Threads. Die Standardanzahl von Threads ist 10.
+Um Threads zu deaktivieren, geben Sie eine nicht positive Nummer an.
 .br
 Kommandozeilenoption: \fB\-\-threads\fP
 .TP 

--- a/doc/en/linkchecker.1
+++ b/doc/en/linkchecker.1
@@ -72,7 +72,7 @@ Read list of white-space separated URLs to check from stdin.
 .TP
 \fB\-t\fP\fINUMBER\fP, \fB\-\-threads=\fP\fINUMBER\fP
 Generate no more than the given number of threads. Default number
-of threads is 100. To disable threading specify a non-positive number.
+of threads is 10. To disable threading specify a non-positive number.
 .TP
 \fB\-V\fP, \fB\-\-version\fP
 Print version and exit.

--- a/doc/en/linkcheckerrc.5
+++ b/doc/en/linkcheckerrc.5
@@ -43,7 +43,7 @@ Command line option: \fB\-\-recursion\-level\fP
 .TP
 \fBthreads=\fP\fINUMBER\fP
 Generate no more than the given number of threads. Default number
-of threads is 100. To disable threading specify a non-positive number.
+of threads is 10. To disable threading specify a non-positive number.
 .br
 Command line option: \fB\-\-threads\fP
 .TP

--- a/doc/linkchecker.doc.pot
+++ b/doc/linkchecker.doc.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2014-04-28 17:04+0300\n"
+"POT-Creation-Date: 2015-09-15 10:52+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -272,7 +272,7 @@ msgstr ""
 #: en/linkchecker.1:76 en/linkcheckerrc.5:47
 msgid ""
 "Generate no more than the given number of threads. Default number of threads "
-"is 100. To disable threading specify a non-positive number."
+"is 10. To disable threading specify a non-positive number."
 msgstr ""
 
 #. type: TP

--- a/doc/web/media/man1/linkchecker.1.html
+++ b/doc/web/media/man1/linkchecker.1.html
@@ -96,7 +96,7 @@ Help me! Print usage information for this program.
 Read list of white-space separated URLs to check from stdin.
 <DT><B>-t</B><I>NUMBER</I>, <B>--threads=</B><I>NUMBER</I><DD>
 Generate no more than the given number of threads. Default number
-of threads is 100. To disable threading specify a non-positive number.
+of threads is 10. To disable threading specify a non-positive number.
 <DT><B>-V</B>, <B>--version</B><DD>
 Print version and exit.
 </DL>

--- a/doc/web/media/man5/linkcheckerrc.5.html
+++ b/doc/web/media/man5/linkcheckerrc.5.html
@@ -108,7 +108,7 @@ Scan content of URLs for viruses with ClamAV.
 Command line option: <B>--scan-virus</B>
 <DT><B>threads=</B><I>NUMBER</I><DD>
 Generate no more than the given number of threads. Default number
-of threads is 100. To disable threading specify a non-positive number.
+of threads is 10. To disable threading specify a non-positive number.
 <BR>
 
 Command line option: <B>--threads</B>


### PR DESCRIPTION
10 instead of 100 default threads.

Note: Most of the changes were made by hand, even in the generated files, as the current man2html version (3.0.1) doesn't have a -r switch anymore and therefore doesn't work as expected in the Makefile.