### PR TITLE
Use configured timeout value when requesting robots.txt files.

### DIFF
--- a/linkcheck/cache/robots_txt.py
+++ b/linkcheck/cache/robots_txt.py
@@ -34,13 +34,14 @@ class RobotsTxt (object):
     format: {cache key (string) -> robots.txt content (RobotFileParser)}
     """
 
-    def __init__ (self, useragent):
+    def __init__ (self, useragent, timeout):
         """Initialize per-URL robots.txt cache."""
         # mapping {URL -> parsed robots.txt}
         self.cache = LFUCache(size=100)
         self.hits = self.misses = 0
         self.roboturl_locks = {}
         self.useragent = useragent
+        self.timeout = timeout
 
     def allows_url (self, url_data):
         """Ask robots.txt allowance."""
@@ -57,7 +58,7 @@ class RobotsTxt (object):
                 rp = self.cache[roboturl]
                 return rp.can_fetch(self.useragent, url_data.url)
             self.misses += 1
-        kwargs = dict(auth=url_data.auth, session=url_data.session)
+        kwargs = dict(auth=url_data.auth, session=url_data.session, timeout=self.timeout)
         if hasattr(url_data, "proxy") and hasattr(url_data, "proxy_type"):
             kwargs["proxies"] = {url_data.proxytype: url_data.proxy}
         rp = robotparser2.RobotFileParser(**kwargs)

--- a/linkcheck/director/__init__.py
+++ b/linkcheck/director/__init__.py
@@ -128,7 +128,7 @@ def abort_now ():
 def get_aggregate (config):
     """Get an aggregator instance with given configuration."""
     _urlqueue = urlqueue.UrlQueue(max_allowed_urls=config["maxnumurls"])
-    _robots_txt = robots_txt.RobotsTxt(config["useragent"])
+    _robots_txt = robots_txt.RobotsTxt(config["useragent"], config["timeout"])
     plugin_manager = plugins.PluginManager(config)
     result_cache = results.ResultCache()
     return aggregator.Aggregate(config, _urlqueue, _robots_txt, plugin_manager,

--- a/linkcheck/robotparser2.py
+++ b/linkcheck/robotparser2.py
@@ -38,7 +38,7 @@ class RobotFileParser (object):
     """This class provides a set of methods to read, parse and answer
     questions about a single robots.txt file."""
 
-    def __init__ (self, url='', session=None, proxies=None, auth=None):
+    def __init__ (self, url='', session=None, proxies=None, auth=None, timeout=None):
         """Initialize internal entry lists and store given url and
         credentials."""
         self.set_url(url)
@@ -48,6 +48,7 @@ class RobotFileParser (object):
             self.session = session
         self.proxies = proxies
         self.auth = auth
+        self.timeout = timeout
         self._reset()
 
     def _reset (self):
@@ -94,6 +95,8 @@ class RobotFileParser (object):
             kwargs["auth"] = self.auth
         if self.proxies:
             kwargs["proxies"] = self.proxies
+        if self.timeout:
+            kwargs["timeout"] = self.timeout
         try:
             response = self.session.get(self.url, **kwargs)
             response.raise_for_status()


### PR DESCRIPTION
When a remote server is not responding, we have 2 issues.

1) The request for robots.txt takes a long time to fail.
2) When it does fail, `requests.exceptions.Timeout` is not thrown. Instead we get a `requests.exceptions.RequestException`, which does not abort the link check. So we still have to wait for the link check to timeout before moving on.

This patch uses the configured timeout value for robots.txt requests, which will throw `requests.exceptions.Timeout` and abort the current link check if the remote host does not respond after the timeout .
