### PR TITLE
Handle blank srcset attribute.

### DIFF
--- a/linkcheck/htmlutil/linkparse.py
+++ b/linkcheck/htmlutil/linkparse.py
@@ -271,7 +271,10 @@ class LinkFinder (TagFinder):
                 self.found_url(url, name, base)
         elif attr == u'srcset':
             for img_candidate in value.split(u','):
-                url = img_candidate.split()[0]
+                try:
+                    url = img_candidate.split()[0]
+                except IndexError:
+                    url = None
                 self.found_url(url, name, base)
         else:
             self.found_url(value, name, base)


### PR DESCRIPTION
A blank srcset attribute causes an index out of range exception when attempting to iterate over the comma-separated values. 

This patch catches the exception and moves on.
