### PR TITLE
Shore up HtmlSyntaxCheck

### DIFF
--- a/doc/de/linkcheckerrc.5
+++ b/doc/de/linkcheckerrc.5
@@ -477,6 +477,9 @@ Configures the expiration warning time in days.
 .SS [HtmlSyntaxCheck]
 Check the syntax of HTML pages with the online W3C HTML validator.  See
 http://validator.w3.org/docs/api.html.
+.TP
+\fBcheckerurl=\fP\fISTRING\fP
+Use a custom instance of the instance of the W3C HTML Checker.
 
 .SS [HttpHeaderInfo]
 Print HTTP headers in URL info.

--- a/doc/en/linkcheckerrc.5
+++ b/doc/en/linkcheckerrc.5
@@ -476,6 +476,9 @@ Configures the expiration warning time in days.
 .SS \fB[HtmlSyntaxCheck]\fP
 Check the syntax of HTML pages with the online W3C HTML validator.
 See http://validator.w3.org/docs/api.html.
+.TP
+\fBcheckerurl=\fP\fISTRING\fP
+Use a custom instance of the instance of the W3C HTML Checker.
 
 .SS \fB[HttpHeaderInfo]\fP
 Print HTTP headers in URL info.


### PR DESCRIPTION
- Switch from obsolete soap endpoint
- Add configuration option, checkerurl, to customize html checker endpoint
- Fix 'ascii' codec can't encode character (#601)
