### PR TITLE
docs(readme): add linkchecker docker container to readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,6 +32,12 @@ Installation
 See doc/install.txt in the source code archive.
 Python 2.7.2 or later is needed.
 
+Install using Docker
+---------------------
+You can try linkchecker in an isolated enviroment without changing any local files or have to install all the dependencies via a Docker Container:
+
+``docker pull ellerbrock/linkchecker``
+
 Usage
 ------
 Execute ``linkchecker http://www.example.com``.


### PR DESCRIPTION
# Docker Version of linkchecker

Run `linkchecker` via Docker Container without having to install all the dependencies on your local machine ...