### PR TITLE
Fix setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -375,8 +375,7 @@ myemail = "bastian.kleineidam@web.de"
 
 data_files = [
     ('share/linkchecker',
-        ['config/linkcheckerrc',
-        'doc/html/lccollection.qhc', 'doc/html/lcdoc.qch']),
+        ['config/linkcheckerrc']),
     ('share/linkchecker/examples',
         ['cgi-bin/lconline/leer.html.en',
          'cgi-bin/lconline/leer.html.de',


### PR DESCRIPTION
Currently, `pip install .` in the repository directory will fail because it can't find two files, `doc/html/lccollection.qhc` and `doc/html/lcdoc.qch`.

Here I'm simply removing mention of those from `setup.py` so that install will work.

QA
---

After checking out this branch, do:

``` bash
pip install .
```

And check it succeeds.