### PR TITLE
Deprecate repository in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,8 @@
+DEPRECATED
+==========
+
+**This repository is no longer maintained. Use https://github.com/linkcheck/linkchecker instead.**
+
 LinkChecker
 ============
 


### PR DESCRIPTION
As this repository is no longer active. Why not deprecate it and point to the new https://github.com/linkcheck/linkchecker repository instead? 

See #730 